### PR TITLE
Updated comparison table URL and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Responsive Grid Systems Comparison
 
 Comparison Table
-<http://danaonel.github.io/grid-system-comparison>
+<http://danaonel.github.io/grid-system-comparison/comparison-table.html>

--- a/index.html
+++ b/index.html
@@ -7,95 +7,95 @@
   <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,700,300,600,800,400' rel='stylesheet' type='text/css'>
   <title>Responsive Grid Systems Comparison</title>
   <style>
-  * {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 14px;
-    color: #333;
-  }
-  ul:not(.list), ul:not(.list) li  {
-    margin: 0;
-    padding: 0;
-  }
-  ul:not(.list), ul:not(.list) li {
-    list-style: none;
-  }
-  ol  {
-    margin: 0 0 0 15px;
-    padding: 0;
-  }
-  ol li  {
-    margin: 0;
-    padding: 0 0 0 10px;
-  }
-  .test-intro,
-  .test-screenshot {
-    width: 50%;
-    float: left;
-  }
-  .test-screenshot img {
-    width: 100%;
-  }
-  figure {
-    margin:0;
-  }
-  figcaption {
-    text-align: center;
-    font-style: italic;
-  }
-  .small {
-    position: relative;
-  }
-  .legend {
-    position: absolute;
-    color: #ae1c2e;
-  }
-  .small * {
-    font-size: 11px;
-  }
-  .small li,
-  .small p {
-    padding-left: 30px;
-  }
-  h1 {
-    font-size: 18px;
-    color: #000;
-  }
-  a {
-    color: #087d3c;
-  }
-  table {
-    border-collapse: collapse;
-  }
-  th,
-  td {
-    padding: 5px;
-    margin: 0;
-  }
-  
-  th, .th {
-    background: #999;
-    border: 1px solid #888;
-  }
-  th.empty {
-    border-color: #999 #888 #999 #999;
-  }
-  td {
-    border: 1px solid #ccc;
-    text-align: center;
-  }
-  td.criteria {
-    text-align: right;
-  }
-  tr.features td {
-    background-color: #eee;
-  }
-  sup a {
-    font-size: 0.9em;
-    position: relative;
-    top: 0.1em;
-    text-decoration: none;
-    color: #ae1c2e;
-  }
+    * {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 14px;
+      color: #333;
+    }
+    ul:not(.list), ul:not(.list) li  {
+      margin: 0;
+      padding: 0;
+    }
+    ul:not(.list), ul:not(.list) li {
+      list-style: none;
+    }
+    ol  {
+      margin: 0 0 0 15px;
+      padding: 0;
+    }
+    ol li  {
+      margin: 0;
+      padding: 0 0 0 10px;
+    }
+    .test-intro,
+    .test-screenshot {
+      width: 50%;
+      float: left;
+    }
+    .test-screenshot img {
+      width: 100%;
+    }
+    figure {
+      margin:0;
+    }
+    figcaption {
+      text-align: center;
+      font-style: italic;
+    }
+    .small {
+      position: relative;
+    }
+    .legend {
+      position: absolute;
+      color: #ae1c2e;
+    }
+    .small * {
+      font-size: 11px;
+    }
+    .small li,
+    .small p {
+      padding-left: 30px;
+    }
+    h1 {
+      font-size: 18px;
+      color: #000;
+    }
+    a {
+      color: #087d3c;
+    }
+    table {
+      border-collapse: collapse;
+    }
+    th,
+    td {
+      padding: 5px;
+      margin: 0;
+    }
+
+    th, .th {
+      background: #999;
+      border: 1px solid #888;
+    }
+    th.empty {
+      border-color: #999 #888 #999 #999;
+    }
+    td {
+      border: 1px solid #ccc;
+      text-align: center;
+    }
+    td.criteria {
+      text-align: right;
+    }
+    tr.features td {
+      background-color: #eee;
+    }
+    sup a {
+      font-size: 0.9em;
+      position: relative;
+      top: 0.1em;
+      text-decoration: none;
+      color: #ae1c2e;
+    }
   </style>
 </head>
 
@@ -116,8 +116,8 @@
         <li>Various column widths and combinations</li>
         <li>With the exception of class names, the html structure stays the same.</li>
       </ul>
-      <p>The CSS specific to the grid was separated in its own file (css/grid.css) to measure the results of the test more accurately.</p> 
-      <p>All the tested grid systems contain only grid styles (with the exception of Skeleton which is more of a bootstrap).</p>      
+      <p>The CSS specific to the grid was separated in its own file (css/grid.css) to measure the results of the test more accurately.</p>
+      <p>All the tested grid systems contain only grid styles (with the exception of Skeleton which is more of a bootstrap).</p>
     </div>
     <div class="test-screenshot">
       <figure>
@@ -381,7 +381,7 @@
         <li><strong>Abundant</strong> (many documentation sources).</li>
       </ul>
     </div>
-    
+
     <h2>Conclusions</h2>
     <ol>
       <li>There is no perfect grid system. It all depends on the project and a variety of factors. See "Key questions to choose a grid system" below.</li>
@@ -392,7 +392,7 @@
       <li>If the project is small and simple, it's ok to go with a presentational grid system.</li>
       <li>All semantic grid systems have the potential to generate presentational css, whereas presentational grid systems can never be semantic.</li>
     </ol>
-    
+
     <h2>Key questions to choose a grid system</h2>
     <ol>
       <li>How large is the project?</li>


### PR DESCRIPTION
Comparison table URL was edited to point to the correct URL and some HTML formatting was adjusted so text editors would collapse the <style> tag.
